### PR TITLE
アップデート

### DIFF
--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -2,6 +2,7 @@
 import { useAuth } from "@/api";
 import { userState } from "@/recoil";
 import { Rampart_One } from "next/font/google";
+import Link from "next/link";
 import { useEffect } from "react";
 import { FaGithub } from "react-icons/fa";
 import { useRecoilValue } from "recoil";
@@ -60,13 +61,22 @@ export default function Home() {
           </span>
         </h3>
         <div className="m-auto">
-          <button
-            onClick={login}
-            className="flex justify-center items-center gap-1 p-4 bg-gray-700 text-white rounded hover:bg-gray-600 transition-all"
-          >
-            <FaGithub className="text-xl" />
-            GitHubでログインする
-          </button>
+          {user.id ? (
+            <Link
+              href="/record"
+              className="flex justify-center items-center gap-1 p-4 bg-gray-700 text-white rounded hover:bg-gray-600 transition-all"
+            >
+              <span className="text-green-300">草</span>を生やしに行く
+            </Link>
+          ) : (
+            <button
+              onClick={login}
+              className="flex justify-center items-center gap-1 p-4 bg-gray-700 text-white rounded hover:bg-gray-600 transition-all"
+            >
+              <FaGithub className="text-xl" />
+              GitHubでログインする
+            </button>
+          )}
         </div>
         <div className="text-start text-sm">
           <p>

--- a/front/src/app/record/[name]/page.tsx
+++ b/front/src/app/record/[name]/page.tsx
@@ -17,7 +17,7 @@ export default function RecordPage({
 }) {
   const [fileName, setFileName] = useState("");
   const [currentFile, setCurrentFile] = useState<IFile>({
-    id: -1,
+    id: 0,
     name: "",
     path: "",
     content: "",
@@ -66,6 +66,7 @@ export default function RecordPage({
       });
 
       setAllFile(files);
+      setCurrentFile(files[0]);
     } catch (e) {
       alert("エラーが発生しました");
       router.push("/");
@@ -113,6 +114,7 @@ export default function RecordPage({
   };
 
   const handleSelectFile = (id: string) => {
+    console.log(id);
     const selectedFile = allFile.find((file) => file.id === Number(id));
     if (!selectedFile || selectedFile.id === currentFile.id) {
       return;
@@ -121,10 +123,8 @@ export default function RecordPage({
     const updateAllFile = allFile
       .map((file) => {
         if (file.id === currentFile.id) {
-          console.log(currentFile);
           return currentFile;
         }
-        console.log(file);
         return file;
       })
       .filter((file): file is IFile => file !== null);
@@ -407,10 +407,7 @@ export default function RecordPage({
             ファイル操作
           </Shadcn.DrawerTrigger>
           <Shadcn.DrawerContent>
-            <Shadcn.Select
-              defaultValue={currentFile.name}
-              onValueChange={handleSelectFile}
-            >
+            <Shadcn.Select onValueChange={handleSelectFile}>
               <div className="flex flex-col px-3 w-full justify-center items-center">
                 <span className="text-end w-full text-xs">ファイル選択</span>
                 <Shadcn.SelectTrigger className="w-full">

--- a/front/src/app/record/[name]/page.tsx
+++ b/front/src/app/record/[name]/page.tsx
@@ -6,10 +6,8 @@ import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { FaFile } from "react-icons/fa";
 import { IFile } from "@/types";
-import * as Shadcn from "@/components/shadcn";
 import { recordsState } from "@/recoil";
 import { useRecoilState } from "recoil";
-import { all } from "axios";
 
 export default function RecordPage({
   params: { name },
@@ -82,10 +80,26 @@ export default function RecordPage({
 
   const handleCreateFile = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+
+    if (!/^[a-zA-Z0-9_.-]+$/.test(fileName)) {
+      alert("ファイル名に使用できない文字が含まれています");
+      return;
+    }
+
+    const fileExtension = fileName.includes(".")
+      ? fileName.split(".").pop()
+      : "";
+    const newFileName = fileName.includes(".")
+      ? fileName.split(".").shift() + "."
+      : fileName;
+    const newFilePath = `${newFileName}${
+      fileExtension === "" ? ".md" : fileExtension
+    }`;
+
     if (
       allFile
         ?.filter((file) => !file.is_delete)
-        .some((file) => file.name === fileName)
+        .some((file) => file.path === newFilePath)
     ) {
       alert("ファイル名が重複しています");
       return;
@@ -93,8 +107,8 @@ export default function RecordPage({
 
     const newFile = {
       id: allFile[allFile.length - 1]?.id + 1 || 0,
-      name: fileName,
-      path: fileName,
+      name: newFilePath,
+      path: newFilePath,
       content: "",
       is_delete: false,
       old_path: "",
@@ -305,13 +319,12 @@ export default function RecordPage({
               <h3 className="text-start mb-2">記録</h3>
               <div className="ml-3 overflow-hidden">
                 <form className="w-full mb-4" onSubmit={handleCreateFile}>
-                  <span className="text-xs">※拡張子もつけてください</span>
                   <input
                     type="text"
                     className="rounded w-full text-black p-1 px-2 focus:outline-none"
                     onChange={(e) => setFileName(e.target.value)}
                     value={fileName}
-                    placeholder="README.md"
+                    placeholder="README"
                   />
                   <button
                     className={`text-sm text-center block m-auto w-full tracking-widest my-1 py-1 rounded hover:bg-slate-950 transition-all hover:text-white ${

--- a/front/src/app/record/[name]/page.tsx
+++ b/front/src/app/record/[name]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { authClient } from "@/api";
-import { Editor } from "@/components/records";
+import { Editor, FixedButtonPC, FixedButtonSP } from "@/components/records";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { FaFile } from "react-icons/fa";
@@ -9,6 +9,7 @@ import { IFile } from "@/types";
 import * as Shadcn from "@/components/shadcn";
 import { recordsState } from "@/recoil";
 import { useRecoilState } from "recoil";
+import { all } from "axios";
 
 export default function RecordPage({
   params: { name },
@@ -114,7 +115,6 @@ export default function RecordPage({
   };
 
   const handleSelectFile = (id: string) => {
-    console.log(id);
     const selectedFile = allFile.find((file) => file.id === Number(id));
     if (!selectedFile || selectedFile.id === currentFile.id) {
       return;
@@ -356,108 +356,34 @@ export default function RecordPage({
             </section>
           )}
 
-          {currentFile?.name && (
-            <>
-              <section className="md:my-8 rounded p-2 w-full md:w-4/5 h-full">
-                <div className="bg-slate-700 w-full h-full rounded">
-                  <Editor
-                    currentFile={currentFile}
-                    setCurrentFile={setCurrentFile}
-                  />
-                </div>
-              </section>
-            </>
-          )}
+          <section className="md:my-8 rounded p-2 w-full md:w-4/5 h-full">
+            <div className="bg-slate-700 w-full h-full rounded">
+              <Editor
+                currentFile={currentFile}
+                setCurrentFile={setCurrentFile}
+                isLoading={isLoading}
+              />
+            </div>
+          </section>
         </div>
       </article>
-      <article className="fixed w-full bottom-10 right-0 md:w-4/5 md:bottom-12">
-        <section className="hidden text-black md:flex justify-center items-end">
-          <Shadcn.Menubar className="flex items-center py-6">
-            <Shadcn.MenubarMenu>
-              <Shadcn.MenubarTrigger
-                className="cursor-pointer hover:bg-slate-700 hover:text-white transition-all"
-                onClick={handleChangeFileName}
-              >
-                ファイル名変更
-              </Shadcn.MenubarTrigger>
-            </Shadcn.MenubarMenu>
-            <Shadcn.MenubarMenu>
-              <Shadcn.MenubarTrigger
-                className="cursor-pointer hover:bg-slate-700 hover:text-white transition-all"
-                onClick={handleDeleteFile}
-              >
-                ファイル削除
-              </Shadcn.MenubarTrigger>
-            </Shadcn.MenubarMenu>
-            <Shadcn.MenubarMenu>
-              <Shadcn.MenubarTrigger
-                className="cursor-pointer hover:bg-slate-700 hover:text-white transition-all"
-                onClick={handleSave}
-                disabled={isCommit}
-              >
-                コミット
-              </Shadcn.MenubarTrigger>
-            </Shadcn.MenubarMenu>
-          </Shadcn.Menubar>
-        </section>
-      </article>
-      <article className="fixed bottom-8 left-0 w-full flex justify-center items-center gap-2 md:hidden">
-        <Shadcn.Drawer>
-          <Shadcn.DrawerTrigger className="border border-slate-200 px-2 py-1 rounded">
-            ファイル操作
-          </Shadcn.DrawerTrigger>
-          <Shadcn.DrawerContent>
-            <Shadcn.Select onValueChange={handleSelectFile}>
-              <div className="flex flex-col px-3 w-full justify-center items-center">
-                <span className="text-end w-full text-xs">ファイル選択</span>
-                <Shadcn.SelectTrigger className="w-full">
-                  <Shadcn.SelectValue
-                    placeholder={currentFile.name || "ファイル名"}
-                  />
-                </Shadcn.SelectTrigger>
-                <Shadcn.SelectContent>
-                  {allFile
-                    ?.filter((file) => !file.is_delete)
-                    .map((file, index) => (
-                      <Shadcn.SelectItem key={index} value={String(file.id)}>
-                        {file.name}
-                      </Shadcn.SelectItem>
-                    ))}
-                </Shadcn.SelectContent>
-              </div>
-            </Shadcn.Select>
-            <Shadcn.DrawerFooter>
-              <div className="flex justify-end items-center mr-2 my-3 gap-2">
-                <button
-                  className="bg-red-400 text-white px-2 p-1 rounded"
-                  onClick={handleDeleteFile}
-                >
-                  削除
-                </button>
-                <button
-                  className="rounded border border-slate-300 px-2 py-1"
-                  onClick={handleChangeFileName}
-                >
-                  ファイル名変更
-                </button>
-                <button
-                  className="rounded border border-slate-300 px-2 py-1"
-                  onClick={handleCreateFileSP}
-                >
-                  新規作成
-                </button>
-              </div>
-              <Shadcn.DrawerClose>戻る</Shadcn.DrawerClose>
-            </Shadcn.DrawerFooter>
-          </Shadcn.DrawerContent>
-        </Shadcn.Drawer>
-        <button
-          onClick={handleSave}
-          className="px-2 py-1 border border-white rounded"
-        >
-          コミット
-        </button>
-      </article>
+
+      <FixedButtonPC
+        handleChangeFileName={handleChangeFileName}
+        handleDeleteFile={handleDeleteFile}
+        handleSave={handleSave}
+        isCommit={isCommit}
+      />
+      <FixedButtonSP
+        handleSelectFile={handleSelectFile}
+        handleDeleteFile={handleDeleteFile}
+        handleCreateFileSP={handleCreateFileSP}
+        handleChangeFileName={handleChangeFileName}
+        handleSave={handleSave}
+        currentFile={currentFile}
+        allFile={allFile}
+        isCommit={isCommit}
+      />
     </>
   );
 }

--- a/front/src/app/record/[name]/page.tsx
+++ b/front/src/app/record/[name]/page.tsx
@@ -128,6 +128,61 @@ export default function RecordPage({
     setFileName("");
   };
 
+  const handleCreateFileSP = () => {
+    let newFileName = prompt(
+      "新しいファイル名を入力してください\n※拡張子もつけてください"
+    );
+    if (!newFileName) {
+      return;
+    }
+
+    if (!/^[a-zA-Z0-9_.-]+$/.test(newFileName)) {
+      alert("ファイル名に使用できない文字が含まれています");
+      return;
+    }
+
+    const fileExtension = newFileName.includes(".")
+      ? newFileName.split(".").pop()
+      : "";
+    newFileName = newFileName.includes(".")
+      ? newFileName.split(".").shift() + "."
+      : newFileName;
+    const newFilePath = `${newFileName}${
+      fileExtension === "" ? ".md" : fileExtension
+    }`;
+
+    if (
+      allFile
+        ?.filter((file) => !file.is_delete)
+        .some((file) => file.path === newFilePath)
+    ) {
+      alert("ファイル名が重複しています");
+      return;
+    }
+
+    const newFile = {
+      id: allFile[allFile.length - 1]?.id + 1 || 0,
+      name: newFilePath,
+      path: newFilePath,
+      content: "",
+      is_delete: false,
+      old_path: "",
+    };
+
+    const selectFile = allFile.find((file) => file.name === currentFile?.name);
+    let updateAllFile = allFile.map((file) => {
+      if (file.name === selectFile?.name) {
+        return currentFile;
+      }
+      return file;
+    });
+    updateAllFile.push(newFile);
+
+    setAllFile(updateAllFile);
+    setCurrentFile(newFile);
+    setFileName("");
+  };
+
   const handleSelectFile = (id: string) => {
     const selectedFile = allFile.find((file) => file.id === Number(id));
     if (!selectedFile || selectedFile.id === currentFile.id) {
@@ -252,42 +307,6 @@ export default function RecordPage({
     } finally {
       setIsCommit(false);
     }
-  };
-
-  const handleCreateFileSP = () => {
-    const newFileName = prompt(
-      "新しいファイル名を入力してください\n※拡張子もつけてください"
-    );
-    if (!newFileName) {
-      return;
-    }
-
-    if (allFile?.some((file) => file.name === newFileName)) {
-      alert("ファイル名が重複しています");
-      return;
-    }
-
-    const newFile = {
-      id: allFile[allFile.length - 1]?.id + 1 || 0,
-      name: newFileName,
-      path: newFileName,
-      content: "",
-      is_delete: false,
-      old_path: "",
-    };
-
-    const selectFile = allFile.find((file) => file.name === currentFile?.name);
-    let updateAllFile = allFile.map((file) => {
-      if (file.name === selectFile?.name) {
-        return currentFile;
-      }
-      return file;
-    });
-    updateAllFile.push(newFile);
-
-    setAllFile(updateAllFile);
-    setCurrentFile(newFile);
-    setFileName("");
   };
 
   return (

--- a/front/src/app/record/page.tsx
+++ b/front/src/app/record/page.tsx
@@ -24,7 +24,6 @@ export default function UserPage() {
     const expiry = queryParams.get("expiry");
     let logged = false;
     try {
-      setIsLoading(true);
       if (uid && client && token && expiry) {
         await currentUser({ uid, client, token, expiry }).then(
           (res) => (logged = res)
@@ -41,13 +40,14 @@ export default function UserPage() {
     } catch (e) {
       alert("エラーが発生しました");
       router.push("/");
-    } finally {
-      setIsLoading(false);
     }
   }, []);
 
   const fetchRecords = useCallback(async () => {
-    if (records.length > 0) return;
+    if (records.length > 0) {
+      setIsLoading(false);
+      return;
+    }
     try {
       setIsLoading(true);
       const res = await authClient.get("/records");
@@ -74,7 +74,6 @@ export default function UserPage() {
 
   useEffect(() => {
     fetchRecords();
-    setIsLoading(false);
   }, [fetchRecords]);
 
   return (

--- a/front/src/components/layouts/footer.tsx
+++ b/front/src/components/layouts/footer.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 export default function Footer() {
   return (
     <div className="mt-8 mb-2">
-      <ul className="flex flex-col md:flex-row items-end mr-2 md:m-auto justify-center md:items-center text-xs gap-2">
+      <ul className="flex flex-col md:flex-row items-start ml-2 md:m-auto justify-center md:items-center text-xs gap-2">
         <li>©2024 Leaf Record</li>
         <li>
           <Link href="/privacypolicy">プライバシーポリシー</Link>

--- a/front/src/components/layouts/header.tsx
+++ b/front/src/components/layouts/header.tsx
@@ -25,80 +25,89 @@ export default function Header() {
   };
 
   return (
-    <div className="container flex justify-between items-center m-auto p-2 px-4">
-      <h1
-        className={`text-xl md:text-3xl md:flex md:justify-center ${RampartOneFont.className}`}
-      >
-        <Link
-          href="/"
-          className="flex flex-col md:flex-row justify-center items-center md:gap-2"
+    <>
+      <div className="container flex justify-between items-center m-auto p-2 px-4">
+        <h1
+          className={`text-xl md:text-3xl md:flex md:justify-center ${RampartOneFont.className}`}
         >
-          Leaf Record
-          <span className="text-sm md:text-xl"> ～大草原不可避～</span>
-        </Link>
-      </h1>
-      <nav className="hidden md:block">
-        <ul
-          className={`grid ${
-            user.id ? "grid-cols-2" : "grid-cols-1"
-          } justify-center items-center text-center`}
-        >
-          {user.id ? (
-            <>
-              <li>
-                <Link
-                  href="/record"
-                  className="p-4 flex justify-center items-center hover:bg-white hover:text-black transition-all rounded"
-                >
-                  {user.name}
-                </Link>
-              </li>
+          <Link
+            href="/"
+            className="flex flex-col md:flex-row justify-center items-center md:gap-2"
+          >
+            Leaf Record
+            <span className="text-sm md:text-xl"> ～大草原不可避～</span>
+          </Link>
+        </h1>
+        <nav className="hidden md:block">
+          <ul
+            className={`grid ${
+              user.id ? "grid-cols-2" : "grid-cols-1"
+            } justify-center items-center text-center`}
+          >
+            {user.id ? (
+              <>
+                <li>
+                  <Link
+                    href="/record"
+                    className="p-4 flex justify-center items-center hover:bg-white hover:text-black transition-all rounded"
+                  >
+                    {user.name}
+                  </Link>
+                </li>
 
+                <li>
+                  <button
+                    onClick={handleLogout}
+                    className="p-4 flex justify-center items-center hover:bg-white hover:text-black transition-all rounded"
+                  >
+                    ログアウト
+                  </button>
+                </li>
+              </>
+            ) : (
               <li>
                 <button
-                  onClick={handleLogout}
+                  onClick={login}
                   className="p-4 flex justify-center items-center hover:bg-white hover:text-black transition-all rounded"
                 >
-                  ログアウト
+                  ログイン
                 </button>
               </li>
-            </>
-          ) : (
-            <li>
-              <button
-                onClick={login}
-                className="p-4 flex justify-center items-center hover:bg-white hover:text-black transition-all rounded"
-              >
-                ログイン
-              </button>
-            </li>
-          )}
-        </ul>
-      </nav>
-      <Shadcn.Menubar className="bg-gray-600 border-gray-600 md:hidden">
+            )}
+          </ul>
+        </nav>
+      </div>
+      <Shadcn.Menubar className="fixed bottom-2 right-2 bg-transparent z-10 md:hidden">
         <Shadcn.MenubarMenu>
-          <Shadcn.MenubarTrigger className="bg-gray-600 border-gray-600 focus:bg-slate-300">
-            Menu
-          </Shadcn.MenubarTrigger>
-          <Shadcn.MenubarContent className="bg-slate-300 border-slate-300 px-3 mr-4">
+          <Shadcn.MenubarTrigger>Menu</Shadcn.MenubarTrigger>
+          <Shadcn.MenubarContent className="bg-slate-300 border-slate-300 mr-2">
             {user.id ? (
               <>
                 <Shadcn.MenubarItem>
-                  <Link href="/record">{user.name}</Link>
+                  <Link href="/record" className="w-full h-full text-end px-2">
+                    {user.name}
+                  </Link>
                 </Shadcn.MenubarItem>
                 <Shadcn.MenubarSeparator className="bg-slate-400" />
                 <Shadcn.MenubarItem>
-                  <button onClick={handleLogout}>ログアウト</button>
+                  <button
+                    onClick={handleLogout}
+                    className="w-full h-full text-end px-2"
+                  >
+                    ログアウト
+                  </button>
                 </Shadcn.MenubarItem>
               </>
             ) : (
               <Shadcn.MenubarItem>
-                <button onClick={login}>ログイン</button>
+                <button onClick={login} className="w-full h-full">
+                  ログイン
+                </button>
               </Shadcn.MenubarItem>
             )}
           </Shadcn.MenubarContent>
         </Shadcn.MenubarMenu>
       </Shadcn.Menubar>
-    </div>
+    </>
   );
 }

--- a/front/src/components/records/editor.tsx
+++ b/front/src/components/records/editor.tsx
@@ -4,9 +4,11 @@ import { IFile } from "@/types";
 const Editor = ({
   currentFile,
   setCurrentFile,
+  isLoading,
 }: {
   currentFile: IFile;
   setCurrentFile: (currentFile: IFile) => void;
+  isLoading: boolean;
 }) => {
   const INIT_ROWS = 50;
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
@@ -31,14 +33,24 @@ const Editor = ({
   };
 
   return (
-    <textarea
-      ref={textAreaRef}
-      rows={rows}
-      className="w-full bg-transparent p-4 focus:outline-none resize-none overflow-hidden rounded resize-x-none"
-      value={currentFile?.content ? currentFile.content : ""}
-      onChange={handleUpdateContent}
-      placeholder="ここに記録を書けるよ！"
-    />
+    <>
+      {isLoading ? (
+        <div className="h-screen animate-pulse">
+          <div className="rounded h-full bg-slate-300 opacity-50 flex justify-center items-start">
+            <p className="text-slate-800 text-xl mt-24">読込中</p>
+          </div>
+        </div>
+      ) : (
+        <textarea
+          ref={textAreaRef}
+          rows={rows}
+          className="w-full bg-transparent p-4 focus:outline-none resize-none overflow-hidden rounded resize-x-none"
+          value={currentFile?.content ? currentFile.content : ""}
+          onChange={handleUpdateContent}
+          placeholder="ここに記録を書けるよ！"
+        />
+      )}
+    </>
   );
 };
 

--- a/front/src/components/records/editor.tsx
+++ b/front/src/components/records/editor.tsx
@@ -44,7 +44,7 @@ const Editor = ({
         <textarea
           ref={textAreaRef}
           rows={rows}
-          className="w-full bg-transparent p-4 focus:outline-none resize-none overflow-hidden rounded resize-x-none"
+          className="w-full bg-transparent p-4 focus:outline-none resize-none overflow-x-hidden rounded resize-x-none"
           value={currentFile?.content ? currentFile.content : ""}
           onChange={handleUpdateContent}
           placeholder="ここに記録を書けるよ！"

--- a/front/src/components/records/fixedButton.tsx
+++ b/front/src/components/records/fixedButton.tsx
@@ -53,6 +53,8 @@ export function FixedButtonSP({
   currentFile,
   allFile,
   isCommit,
+  isDrawerOpen,
+  setIsDrawerOpen,
 }: {
   handleSelectFile: (value: string) => void;
   handleDeleteFile: () => void;
@@ -62,10 +64,16 @@ export function FixedButtonSP({
   currentFile: { name: string };
   allFile: { id: number; name: string; is_delete: boolean }[];
   isCommit: boolean;
+  isDrawerOpen: boolean;
+  setIsDrawerOpen: (isDrawerOpen: boolean) => void;
 }) {
   return (
     <article className="fixed bottom-12 right-0 w-full flex justify-end items-center gap-1 md:hidden mx-2">
-      <Shadcn.Drawer>
+      <Shadcn.Drawer
+        open={isDrawerOpen}
+        onOpenChange={setIsDrawerOpen}
+        onClose={() => setIsDrawerOpen(false)}
+      >
         <Shadcn.DrawerTrigger className="border border-slate-200 px-2 py-1 rounded">
           ファイル操作
         </Shadcn.DrawerTrigger>

--- a/front/src/components/records/fixedButton.tsx
+++ b/front/src/components/records/fixedButton.tsx
@@ -1,0 +1,128 @@
+"use client";
+import * as Shadcn from "@/components/shadcn";
+import React, { useState } from "react";
+
+export function FixedButtonPC({
+  handleChangeFileName,
+  handleDeleteFile,
+  handleSave,
+  isCommit,
+}: {
+  handleChangeFileName: () => void;
+  handleDeleteFile: () => void;
+  handleSave: () => void;
+  isCommit: boolean;
+}) {
+  return (
+    <article className="fixed w-full bottom-10 right-0 md:w-4/5 md:bottom-12">
+      <section className="hidden text-black md:flex justify-center items-end">
+        <div className="border border-slate-200 py-2 rounded text-white">
+          <button
+            className="px-2 border-r border-white text-red-300"
+            onClick={handleDeleteFile}
+          >
+            ファイル削除
+          </button>
+          <button
+            className="px-2 border-r border-white"
+            onClick={handleChangeFileName}
+          >
+            ファイル名変更
+          </button>
+          <button
+            className={`px-2 ${
+              isCommit ? "text-green-300 cursor-not-allowed" : ""
+            }`}
+            onClick={handleSave}
+            disabled={isCommit}
+          >
+            コミット<span className={isCommit ? "" : "hidden"}>中</span>
+          </button>
+        </div>
+      </section>
+    </article>
+  );
+}
+
+export function FixedButtonSP({
+  handleSelectFile,
+  handleDeleteFile,
+  handleChangeFileName,
+  handleCreateFileSP,
+  handleSave,
+  currentFile,
+  allFile,
+  isCommit,
+}: {
+  handleSelectFile: (value: string) => void;
+  handleDeleteFile: () => void;
+  handleChangeFileName: () => void;
+  handleCreateFileSP: () => void;
+  handleSave: () => void;
+  currentFile: { name: string };
+  allFile: { id: number; name: string; is_delete: boolean }[];
+  isCommit: boolean;
+}) {
+  return (
+    <article className="fixed bottom-12 right-0 w-full flex justify-end items-center gap-1 md:hidden mx-2">
+      <Shadcn.Drawer>
+        <Shadcn.DrawerTrigger className="border border-slate-200 px-2 py-1 rounded">
+          ファイル操作
+        </Shadcn.DrawerTrigger>
+        <Shadcn.DrawerContent>
+          <Shadcn.Select onValueChange={handleSelectFile}>
+            <div className="flex flex-col px-3 w-full justify-center items-center relative">
+              <span className="text-end w-full text-xs">ファイル選択</span>
+              <Shadcn.SelectTrigger className="w-full">
+                <Shadcn.SelectValue
+                  placeholder={currentFile.name || "ファイル名"}
+                />
+              </Shadcn.SelectTrigger>
+              <Shadcn.SelectContent className="absolute bottom-0">
+                {allFile
+                  ?.filter((file) => !file.is_delete)
+                  .map((file, index) => (
+                    <Shadcn.SelectItem key={index} value={String(file.id)}>
+                      {file.name}
+                    </Shadcn.SelectItem>
+                  ))}
+              </Shadcn.SelectContent>
+            </div>
+          </Shadcn.Select>
+          <Shadcn.DrawerFooter>
+            <div className="flex justify-end items-center mr-2 my-3 gap-2">
+              <button
+                className="bg-red-400 text-white px-2 p-1 rounded"
+                onClick={handleDeleteFile}
+              >
+                削除
+              </button>
+              <button
+                className="rounded border border-slate-300 px-2 py-1"
+                onClick={handleChangeFileName}
+              >
+                ファイル名変更
+              </button>
+              <button
+                className="rounded border border-slate-300 px-2 py-1"
+                onClick={handleCreateFileSP}
+              >
+                新規作成
+              </button>
+            </div>
+            <Shadcn.DrawerClose>戻る</Shadcn.DrawerClose>
+          </Shadcn.DrawerFooter>
+        </Shadcn.DrawerContent>
+      </Shadcn.Drawer>
+      <button
+        onClick={handleSave}
+        className={`px-2 py-1 border border-white rounded ${
+          isCommit ? "text-green-300 border-green-300" : ""
+        }`}
+        disabled={isCommit}
+      >
+        コミット<span className={isCommit ? "" : "hidden"}>中</span>
+      </button>
+    </article>
+  );
+}

--- a/front/src/components/records/index.tsx
+++ b/front/src/components/records/index.tsx
@@ -1,5 +1,6 @@
 import Editor from "./editor";
 import RecordList from "./recordList";
 import CreateRecord from "./createRecord";
+import { FixedButtonPC, FixedButtonSP } from "./fixedButton";
 
-export { Editor, RecordList, CreateRecord };
+export { Editor, RecordList, CreateRecord, FixedButtonPC, FixedButtonSP };

--- a/front/src/components/records/recordList.tsx
+++ b/front/src/components/records/recordList.tsx
@@ -11,16 +11,16 @@ export default function RecordList({
 }) {
   return (
     <ul className="flex flex-col gap-2  md:grid md:grid-cols-3">
-      {records.length === 0 && !isLoading && (
-        <li>
-          <p>記録がありません</p>
-        </li>
-      )}
       {isLoading && (
         <li className="w-full h-[48px] animate-pulse">
           <div className="rounded h-full bg-slate-300 opacity-50 flex justify-center items-center">
             <p className="text-black text-center">読込中</p>
           </div>
+        </li>
+      )}
+      {records.length === 0 && !isLoading && (
+        <li>
+          <p>記録がありません</p>
         </li>
       )}
       {records.length > 0 &&

--- a/front/src/components/shadcn/menubar.tsx
+++ b/front/src/components/shadcn/menubar.tsx
@@ -40,7 +40,7 @@ const MenubarTrigger = React.forwardRef<
   <MenubarPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center rounded-sm px-3 py-3 text-sm font-medium outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
+      "flex cursor-default select-none items-center rounded-sm px-3 py-3 text-sm font-medium outline-none",
       className
     )}
     {...props}
@@ -99,7 +99,7 @@ const MenubarContent = React.forwardRef<
         alignOffset={alignOffset}
         sideOffset={sideOffset}
         className={cn(
-          "z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "z-50 min-w-[6rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           className
         )}
         {...props}


### PR DESCRIPTION
- スマホでファイルの新規作成ができない不具合修正
- トップページのログインボタンをスクロールしなくても良いように修正
- スラッシュから始まるとコミットが出来ない
   ⇨ GitHubの仕様。バリデーションかけた
- スマホからやるとテキストエリアが見切れる
   ⇨y軸のみスクロール発生で暫定処理
- ファイル操作周りのUIを修正
- トップページでログイン状態であればログインの文言を変更
- 拡張子を記入しなければ自動的にmd形式になるよう修正
- コミット中のときは表記＋非活性するよう修正
- スマホから新規作成・ファイル名変更をしたあとドロワーを非表示に修正
- ファイル選択を上川に表示スルよう修正