### PR TITLE
【fix】OGPのパスを絶対パスに修正

### DIFF
--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -40,7 +40,7 @@ export const metadata: Metadata = {
     url: process.env.NEXT_PUBLIC_APP_URL,
     images: [
       {
-        url: "ogp.png",
+        url: `${process.env.NEXT_PUBLIC_URL}/ogp.png`,
         width: 1200,
         height: 630,
         alt: APP_NAME,


### PR DESCRIPTION
## 概要
OGPのパスが絶対パスではなく相対パスになっていたので修正しました。

## 補足
環境変数を利用しているので下記の対応が必要です。
frontディレクトリ内の`.env.local`に下記を追記
```
NEXT_PUBLIC_URL=https://localhost:8000
```
本環境では`NEXT_PUBLIC_URL`にフロントのURLを入れてください。