### PR TITLE
test: バックエンドRSpecテスト追加

### DIFF
--- a/back/.rspec
+++ b/back/.rspec
@@ -1,0 +1,3 @@
+--require spec_helper
+--format documentation
+--color

--- a/back/Gemfile
+++ b/back/Gemfile
@@ -36,9 +36,12 @@ gem "bootsnap", require: false
 gem "rack-cors"
 
 group :development, :test do
-  # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]
   gem 'pry-byebug'
+  gem 'rspec-rails'
+  gem 'factory_bot_rails'
+  gem 'shoulda-matchers'
+  gem 'webmock'
 end
 
 group :development do

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -96,6 +96,9 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
+    crack (1.0.1)
+      bigdecimal
+      rexml
     crass (1.0.6)
     date (3.3.4)
     debug (1.9.2)
@@ -109,18 +112,25 @@ GEM
       warden (~> 1.2.3)
     devise-i18n (1.12.0)
       devise (>= 4.9.0)
+    diff-lcs (1.6.2)
     dotenv (3.1.0)
     dotenv-rails (3.1.0)
       dotenv (= 3.1.0)
       railties (>= 6.1)
     drb (2.2.1)
     erubi (1.12.0)
+    factory_bot (6.5.6)
+      activesupport (>= 6.1.0)
+    factory_bot_rails (6.5.1)
+      factory_bot (~> 6.5)
+      railties (>= 6.1.0)
     faraday (2.9.0)
       faraday-net_http (>= 2.0, < 3.2)
     faraday-net_http (3.1.0)
       net-http
     globalid (1.2.1)
       activesupport (>= 6.1)
+    hashdiff (1.2.1)
     hashie (5.0.0)
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
@@ -250,9 +260,29 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rexml (3.4.4)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.8)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-rails (7.1.1)
+      actionpack (>= 7.0)
+      activesupport (>= 7.0)
+      railties (>= 7.0)
+      rspec-core (~> 3.13)
+      rspec-expectations (~> 3.13)
+      rspec-mocks (~> 3.13)
+      rspec-support (~> 3.13)
+    rspec-support (3.13.7)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
+    shoulda-matchers (7.0.1)
+      activesupport (>= 7.1)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -266,6 +296,10 @@ GEM
     version_gem (1.1.4)
     warden (1.2.9)
       rack (>= 2.0.9)
+    webmock (3.26.2)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -282,6 +316,7 @@ DEPENDENCIES
   devise-i18n
   devise_token_auth (>= 1.2.0)!
   dotenv-rails
+  factory_bot_rails
   octokit
   omniauth
   omniauth-github
@@ -292,7 +327,10 @@ DEPENDENCIES
   rack-cors
   rails (~> 7.1.3, >= 7.1.3.2)
   rails_same_site_cookie
+  rspec-rails
+  shoulda-matchers
   tzinfo-data
+  webmock
 
 RUBY VERSION
    ruby 3.3.0p0

--- a/back/config/database.yml
+++ b/back/config/database.yml
@@ -59,6 +59,9 @@ development:
 test:
   <<: *default
   database: app_test
+  host: <%= ENV.fetch("DB_HOST") { "db" } %>
+  username: <%= ENV.fetch("DB_USERNAME") { "postgres" } %>
+  password: <%= ENV.fetch("DB_PASSWORD") { "password" } %>
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/back/config/environments/test.rb
+++ b/back/config/environments/test.rb
@@ -61,4 +61,6 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  config.hosts << "www.example.com"
 end

--- a/back/spec/factories/records.rb
+++ b/back/spec/factories/records.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :record do
+    sequence(:repository_name) { |n| "repo-#{n}" }
+    association :user
+  end
+end

--- a/back/spec/factories/users.rb
+++ b/back/spec/factories/users.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :user do
+    sequence(:uid) { |n| "github_uid_#{n}" }
+    sequence(:name) { |n| "user#{n}" }
+    provider { 'github' }
+    github_token { { 'token' => 'dummy_encrypted', 'iv' => 'dummy_iv' } }
+    tokens { {} }
+  end
+end

--- a/back/spec/models/record_spec.rb
+++ b/back/spec/models/record_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Record, type: :model do
-  describe 'associations' do
+  describe 'アソシエーション' do
     it { is_expected.to belong_to(:user) }
   end
 
-  describe 'validations' do
+  describe 'バリデーション' do
     it { is_expected.to validate_presence_of(:repository_name) }
     it { is_expected.to validate_length_of(:repository_name).is_at_most(255) }
   end

--- a/back/spec/models/record_spec.rb
+++ b/back/spec/models/record_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe Record, type: :model do
+  describe 'associations' do
+    it { is_expected.to belong_to(:user) }
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:repository_name) }
+    it { is_expected.to validate_length_of(:repository_name).is_at_most(255) }
+  end
+end

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  describe 'associations' do
+    it { is_expected.to have_many(:records).dependent(:destroy) }
+  end
+
+  describe '.from_omniauth' do
+    let(:auth) do
+      double('auth',
+        uid: 'uid_123',
+        provider: 'github',
+        info: double('info', nickname: 'testuser')
+      )
+    end
+
+    context 'when user does not exist' do
+      it 'creates a new user' do
+        expect { User.from_omniauth(auth) }.to change(User, :count).by(1)
+      end
+
+      it 'sets the correct attributes' do
+        user = User.from_omniauth(auth)
+        expect(user.uid).to eq('uid_123')
+        expect(user.name).to eq('testuser')
+        expect(user.provider).to eq('github')
+      end
+    end
+
+    context 'when user already exists' do
+      before { create(:user, uid: 'uid_123', provider: 'github') }
+
+      it 'does not create a duplicate' do
+        expect { User.from_omniauth(auth) }.not_to change(User, :count)
+      end
+    end
+  end
+
+  describe '#new_record' do
+    let(:user) { create(:user) }
+
+    context 'when repository_name is not taken' do
+      it 'returns a new Record instance' do
+        record = user.new_record('new-repo')
+        expect(record).to be_a(Record)
+        expect(record).not_to be_persisted
+      end
+    end
+
+    context 'when repository_name is already taken' do
+      before { create(:record, user: user, repository_name: 'existing-repo') }
+
+      it 'returns nil' do
+        expect(user.new_record('existing-repo')).to be_nil
+      end
+    end
+  end
+end

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  describe 'associations' do
+  describe 'アソシエーション' do
     it { is_expected.to have_many(:records).dependent(:destroy) }
   end
 
@@ -14,12 +14,12 @@ RSpec.describe User, type: :model do
       )
     end
 
-    context 'when user does not exist' do
-      it 'creates a new user' do
+    context 'ユーザーが存在しない場合' do
+      it '新しいユーザーを作成する' do
         expect { User.from_omniauth(auth) }.to change(User, :count).by(1)
       end
 
-      it 'sets the correct attributes' do
+      it '正しい属性を設定する' do
         user = User.from_omniauth(auth)
         expect(user.uid).to eq('uid_123')
         expect(user.name).to eq('testuser')
@@ -27,10 +27,10 @@ RSpec.describe User, type: :model do
       end
     end
 
-    context 'when user already exists' do
+    context 'ユーザーが既に存在する場合' do
       before { create(:user, uid: 'uid_123', provider: 'github') }
 
-      it 'does not create a duplicate' do
+      it '重複して作成しない' do
         expect { User.from_omniauth(auth) }.not_to change(User, :count)
       end
     end
@@ -39,18 +39,18 @@ RSpec.describe User, type: :model do
   describe '#new_record' do
     let(:user) { create(:user) }
 
-    context 'when repository_name is not taken' do
-      it 'returns a new Record instance' do
+    context 'repository_nameが未使用の場合' do
+      it '新しいRecordインスタンスを返す' do
         record = user.new_record('new-repo')
         expect(record).to be_a(Record)
         expect(record).not_to be_persisted
       end
     end
 
-    context 'when repository_name is already taken' do
+    context 'repository_nameが既に使用されている場合' do
       before { create(:record, user: user, repository_name: 'existing-repo') }
 
-      it 'returns nil' do
+      it 'nilを返す' do
         expect(user.new_record('existing-repo')).to be_nil
       end
     end

--- a/back/spec/rails_helper.rb
+++ b/back/spec/rails_helper.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+ENV['RAILS_ENV'] = 'test'
+ENV['GITHUB_TOKEN_ENCRYPT_KEY'] ||= 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
+ENV['FRONT_URL'] ||= 'http://localhost:8000'
+
+require_relative '../config/environment'
+require 'rspec/rails'
+require 'webmock/rspec'
+
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+
+RSpec.configure do |config|
+  config.fixture_paths = ["#{::Rails.root}/spec/fixtures"]
+  config.use_transactional_fixtures = true
+  config.infer_spec_type_from_file_location!
+  config.filter_rails_from_backtrace!
+
+  config.include FactoryBot::Syntax::Methods
+  config.include DeviseTokenAuthHelpers, type: :request
+end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end

--- a/back/spec/requests/api/v1/records_spec.rb
+++ b/back/spec/requests/api/v1/records_spec.rb
@@ -8,17 +8,17 @@ RSpec.describe 'Api::V1::Records', type: :request do
   before { allow(Github).to receive(:new).and_return(github_double) }
 
   describe 'GET /api/v1/records' do
-    context 'when authenticated' do
+    context '認証済みの場合' do
       before { create_list(:record, 3, user: user) }
 
-      it 'returns all records for the current user' do
+      it '現在のユーザーの全レコードを返す' do
         get '/api/v1/records', headers: headers
         expect(response).to have_http_status(:ok)
         json = JSON.parse(response.body)
         expect(json.length).to eq(3)
       end
 
-      it 'returns records sorted by created_at desc' do
+      it 'created_atの降順で返す' do
         get '/api/v1/records', headers: headers
         json = JSON.parse(response.body)
         dates = json.map { |r| r['created_at'] }
@@ -26,8 +26,8 @@ RSpec.describe 'Api::V1::Records', type: :request do
       end
     end
 
-    context 'when not authenticated' do
-      it 'returns 401' do
+    context '未認証の場合' do
+      it '401を返す' do
         get '/api/v1/records'
         expect(response).to have_http_status(:unauthorized)
       end
@@ -37,7 +37,7 @@ RSpec.describe 'Api::V1::Records', type: :request do
   describe 'GET /api/v1/records/:id' do
     let(:record) { create(:record, user: user) }
 
-    context 'when repository exists' do
+    context 'リポジトリが存在する場合' do
       before do
         allow(github_double).to receive(:repository_exists?).and_return(true)
         allow(github_double).to receive(:get_all_files).and_return([
@@ -45,7 +45,7 @@ RSpec.describe 'Api::V1::Records', type: :request do
         ])
       end
 
-      it 'returns files' do
+      it 'ファイル一覧を返す' do
         get "/api/v1/records/#{record.repository_name}", headers: headers
         expect(response).to have_http_status(:ok)
         json = JSON.parse(response.body)
@@ -54,10 +54,10 @@ RSpec.describe 'Api::V1::Records', type: :request do
       end
     end
 
-    context 'when repository does not exist' do
+    context 'リポジトリが存在しない場合' do
       before { allow(github_double).to receive(:repository_exists?).and_return(false) }
 
-      it 'destroys the record and returns error' do
+      it 'レコードを削除してエラーを返す' do
         get "/api/v1/records/#{record.repository_name}", headers: headers
         json = JSON.parse(response.body)
         expect(json['success']).to be false
@@ -67,12 +67,12 @@ RSpec.describe 'Api::V1::Records', type: :request do
   end
 
   describe 'POST /api/v1/records' do
-    context 'when repository_name is available' do
+    context 'repository_nameが利用可能な場合' do
       before do
         allow(github_double).to receive(:create_repository).and_return({ success: true, message: 'created' })
       end
 
-      it 'creates a record' do
+      it 'レコードを作成する' do
         expect {
           post '/api/v1/records', params: { repository_name: 'new-repo' }, headers: headers
         }.to change(Record, :count).by(1)
@@ -81,10 +81,10 @@ RSpec.describe 'Api::V1::Records', type: :request do
       end
     end
 
-    context 'when repository_name is already taken' do
+    context 'repository_nameが既に使用されている場合' do
       before { create(:record, user: user, repository_name: 'existing-repo') }
 
-      it 'does not create a record' do
+      it 'レコードを作成しない' do
         expect {
           post '/api/v1/records', params: { repository_name: 'existing-repo' }, headers: headers
         }.not_to change(Record, :count)
@@ -98,12 +98,12 @@ RSpec.describe 'Api::V1::Records', type: :request do
     let(:record) { create(:record, user: user) }
     let(:files) { [{ name: 'README.md', content: '# Updated', path: 'README.md', is_delete: false, old_path: 'README.md' }] }
 
-    context 'when files are provided' do
+    context 'ファイルが渡された場合' do
       before do
         allow(github_double).to receive(:commit_push).and_return({ success: true })
       end
 
-      it 'calls commit_push and returns success' do
+      it 'commit_pushを呼び出す' do
         patch "/api/v1/records/#{record.repository_name}",
               params: { files: files },
               headers: headers
@@ -111,16 +111,16 @@ RSpec.describe 'Api::V1::Records', type: :request do
       end
     end
 
-    context 'when files are not provided' do
-      it 'returns error' do
+    context 'ファイルが渡されなかった場合' do
+      it 'エラーを返す' do
         patch "/api/v1/records/#{record.repository_name}", headers: headers
         json = JSON.parse(response.body)
         expect(json['success']).to be false
       end
     end
 
-    context 'when record does not exist in DB' do
-      it 'returns error' do
+    context 'レコードがDBに存在しない場合' do
+      it 'エラーを返す' do
         patch '/api/v1/records/nonexistent-repo',
               params: { files: files },
               headers: headers

--- a/back/spec/requests/api/v1/records_spec.rb
+++ b/back/spec/requests/api/v1/records_spec.rb
@@ -1,0 +1,132 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Records', type: :request do
+  let(:user) { create(:user) }
+  let(:headers) { auth_headers(user) }
+  let(:github_double) { instance_double(Github) }
+
+  before { allow(Github).to receive(:new).and_return(github_double) }
+
+  describe 'GET /api/v1/records' do
+    context 'when authenticated' do
+      before { create_list(:record, 3, user: user) }
+
+      it 'returns all records for the current user' do
+        get '/api/v1/records', headers: headers
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json.length).to eq(3)
+      end
+
+      it 'returns records sorted by created_at desc' do
+        get '/api/v1/records', headers: headers
+        json = JSON.parse(response.body)
+        dates = json.map { |r| r['created_at'] }
+        expect(dates).to eq(dates.sort.reverse)
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns 401' do
+        get '/api/v1/records'
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe 'GET /api/v1/records/:id' do
+    let(:record) { create(:record, user: user) }
+
+    context 'when repository exists' do
+      before do
+        allow(github_double).to receive(:repository_exists?).and_return(true)
+        allow(github_double).to receive(:get_all_files).and_return([
+          { name: 'README.md', path: 'README.md', content: '# Hello' }
+        ])
+      end
+
+      it 'returns files' do
+        get "/api/v1/records/#{record.repository_name}", headers: headers
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json['success']).to be true
+        expect(json['files'].length).to eq(1)
+      end
+    end
+
+    context 'when repository does not exist' do
+      before { allow(github_double).to receive(:repository_exists?).and_return(false) }
+
+      it 'destroys the record and returns error' do
+        get "/api/v1/records/#{record.repository_name}", headers: headers
+        json = JSON.parse(response.body)
+        expect(json['success']).to be false
+        expect(Record.find_by(repository_name: record.repository_name)).to be_nil
+      end
+    end
+  end
+
+  describe 'POST /api/v1/records' do
+    context 'when repository_name is available' do
+      before do
+        allow(github_double).to receive(:create_repository).and_return({ success: true, message: 'created' })
+      end
+
+      it 'creates a record' do
+        expect {
+          post '/api/v1/records', params: { repository_name: 'new-repo' }, headers: headers
+        }.to change(Record, :count).by(1)
+        json = JSON.parse(response.body)
+        expect(json['success']).to be true
+      end
+    end
+
+    context 'when repository_name is already taken' do
+      before { create(:record, user: user, repository_name: 'existing-repo') }
+
+      it 'does not create a record' do
+        expect {
+          post '/api/v1/records', params: { repository_name: 'existing-repo' }, headers: headers
+        }.not_to change(Record, :count)
+        json = JSON.parse(response.body)
+        expect(json['success']).to be false
+      end
+    end
+  end
+
+  describe 'PATCH /api/v1/records/:id' do
+    let(:record) { create(:record, user: user) }
+    let(:files) { [{ name: 'README.md', content: '# Updated', path: 'README.md', is_delete: false, old_path: 'README.md' }] }
+
+    context 'when files are provided' do
+      before do
+        allow(github_double).to receive(:commit_push).and_return({ success: true })
+      end
+
+      it 'calls commit_push and returns success' do
+        patch "/api/v1/records/#{record.repository_name}",
+              params: { files: files },
+              headers: headers
+        expect(github_double).to have_received(:commit_push)
+      end
+    end
+
+    context 'when files are not provided' do
+      it 'returns error' do
+        patch "/api/v1/records/#{record.repository_name}", headers: headers
+        json = JSON.parse(response.body)
+        expect(json['success']).to be false
+      end
+    end
+
+    context 'when record does not exist in DB' do
+      it 'returns error' do
+        patch '/api/v1/records/nonexistent-repo',
+              params: { files: files },
+              headers: headers
+        json = JSON.parse(response.body)
+        expect(json['success']).to be false
+      end
+    end
+  end
+end

--- a/back/spec/requests/api/v1/users_spec.rb
+++ b/back/spec/requests/api/v1/users_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 RSpec.describe 'Api::V1::Users', type: :request do
   describe 'GET /api/v1/me' do
-    context 'when authenticated' do
+    context '認証済みの場合' do
       let(:user) { create(:user) }
 
-      it 'returns the current user' do
+      it '現在のユーザー情報を返す' do
         get '/api/v1/me', headers: auth_headers(user)
         expect(response).to have_http_status(:ok)
         json = JSON.parse(response.body)
@@ -14,8 +14,8 @@ RSpec.describe 'Api::V1::Users', type: :request do
       end
     end
 
-    context 'when not authenticated' do
-      it 'returns success: false' do
+    context '未認証の場合' do
+      it 'success: falseを返す' do
         get '/api/v1/me'
         json = JSON.parse(response.body)
         expect(json['success']).to be false

--- a/back/spec/requests/api/v1/users_spec.rb
+++ b/back/spec/requests/api/v1/users_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Users', type: :request do
+  describe 'GET /api/v1/me' do
+    context 'when authenticated' do
+      let(:user) { create(:user) }
+
+      it 'returns the current user' do
+        get '/api/v1/me', headers: auth_headers(user)
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json['success']).to be true
+        expect(json['user']['name']).to eq(user.name)
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns success: false' do
+        get '/api/v1/me'
+        json = JSON.parse(response.body)
+        expect(json['success']).to be false
+      end
+    end
+  end
+end

--- a/back/spec/services/github_spec.rb
+++ b/back/spec/services/github_spec.rb
@@ -12,43 +12,43 @@ RSpec.describe Github do
   subject(:github) { described_class.new(user) }
 
   describe '#repository_exists?' do
-    context 'when repository exists' do
+    context 'リポジトリが存在する場合' do
       before { allow(octokit_client).to receive(:repository).and_return(double('repo')) }
 
-      it 'returns true' do
+      it 'trueを返す' do
         expect(github.repository_exists?('myrepo')).to be true
       end
     end
 
-    context 'when repository does not exist' do
+    context 'リポジトリが存在しない場合' do
       before { allow(octokit_client).to receive(:repository).and_raise(Octokit::NotFound) }
 
-      it 'returns false' do
+      it 'falseを返す' do
         expect(github.repository_exists?('myrepo')).to be false
       end
     end
   end
 
   describe '#create_repository' do
-    context 'when creation succeeds' do
+    context '作成が成功した場合' do
       before do
         allow(octokit_client).to receive(:create_repository).and_return(double('repo', truthy: true))
         allow(octokit_client).to receive(:create_contents)
       end
 
-      it 'returns success' do
+      it 'successを返す' do
         result = github.create_repository('newrepo')
         expect(result[:success]).to be true
       end
     end
 
-    context 'when name already exists' do
+    context 'リポジトリ名が既に存在する場合' do
       before do
         allow(octokit_client).to receive(:create_repository)
           .and_raise(Octokit::Error.new({ status: 422, body: { message: 'name already exists on this account' } }))
       end
 
-      it 'returns a descriptive error' do
+      it 'エラーメッセージを含む失敗を返す' do
         result = github.create_repository('existingrepo')
         expect(result[:success]).to be false
         expect(result[:message]).to include('リポジトリ名が既に存在')
@@ -71,7 +71,7 @@ RSpec.describe Github do
 
     let(:files) { [{ path: 'README.md', old_path: 'README.md', content: '# Hello', is_delete: false }] }
 
-    it 'creates a blob, tree, commit and updates ref' do
+    it 'blob・tree・commitを作成してrefを更新する' do
       github.commit_push('myrepo', files, '2024/01/01 00:00:00')
       expect(octokit_client).to have_received(:create_blob)
       expect(octokit_client).to have_received(:create_tree)
@@ -79,19 +79,19 @@ RSpec.describe Github do
       expect(octokit_client).to have_received(:update_ref)
     end
 
-    context 'when deleting a file' do
+    context 'ファイルを削除する場合' do
       let(:files) { [{ path: 'old.md', old_path: 'old.md', content: '', is_delete: true }] }
 
-      it 'does not create a blob for the deleted file' do
+      it '削除ファイルのblobを作成しない' do
         github.commit_push('myrepo', files, '2024/01/01 00:00:00')
         expect(octokit_client).not_to have_received(:create_blob)
       end
     end
 
-    context 'when renaming a file' do
+    context 'ファイルをリネームする場合' do
       let(:files) { [{ path: 'new.md', old_path: 'old.md', content: '# Renamed', is_delete: false }] }
 
-      it 'creates a blob for the new file and marks the old path for deletion' do
+      it '新しいファイルのblobを作成し、旧パスを削除対象にする' do
         github.commit_push('myrepo', files, '2024/01/01 00:00:00')
         expect(octokit_client).to have_received(:create_blob).once
         expect(octokit_client).to have_received(:create_tree) do |_repo, blobs, _opts|
@@ -101,10 +101,10 @@ RSpec.describe Github do
       end
     end
 
-    context 'when GitHub API raises an error' do
+    context 'GitHub APIがエラーを返した場合' do
       before { allow(octokit_client).to receive(:ref).and_raise(Octokit::Error) }
 
-      it 'returns failure' do
+      it '失敗を返す' do
         result = github.commit_push('myrepo', files, '2024/01/01 00:00:00')
         expect(result[:success]).to be false
       end

--- a/back/spec/services/github_spec.rb
+++ b/back/spec/services/github_spec.rb
@@ -1,0 +1,113 @@
+require 'rails_helper'
+
+RSpec.describe Github do
+  let(:user) { create(:user) }
+  let(:octokit_client) { instance_double(Octokit::Client) }
+
+  before do
+    allow(Decryptor).to receive(:decrypt).and_return('dummy_token')
+    allow(Octokit::Client).to receive(:new).with(access_token: 'dummy_token').and_return(octokit_client)
+  end
+
+  subject(:github) { described_class.new(user) }
+
+  describe '#repository_exists?' do
+    context 'when repository exists' do
+      before { allow(octokit_client).to receive(:repository).and_return(double('repo')) }
+
+      it 'returns true' do
+        expect(github.repository_exists?('myrepo')).to be true
+      end
+    end
+
+    context 'when repository does not exist' do
+      before { allow(octokit_client).to receive(:repository).and_raise(Octokit::NotFound) }
+
+      it 'returns false' do
+        expect(github.repository_exists?('myrepo')).to be false
+      end
+    end
+  end
+
+  describe '#create_repository' do
+    context 'when creation succeeds' do
+      before do
+        allow(octokit_client).to receive(:create_repository).and_return(double('repo', truthy: true))
+        allow(octokit_client).to receive(:create_contents)
+      end
+
+      it 'returns success' do
+        result = github.create_repository('newrepo')
+        expect(result[:success]).to be true
+      end
+    end
+
+    context 'when name already exists' do
+      before do
+        allow(octokit_client).to receive(:create_repository)
+          .and_raise(Octokit::Error.new({ status: 422, body: { message: 'name already exists on this account' } }))
+      end
+
+      it 'returns a descriptive error' do
+        result = github.create_repository('existingrepo')
+        expect(result[:success]).to be false
+        expect(result[:message]).to include('リポジトリ名が既に存在')
+      end
+    end
+  end
+
+  describe '#commit_push' do
+    let(:ref_double) { double('ref', object: double('object', sha: 'base_sha')) }
+    let(:tree_double) { double('tree', sha: 'tree_sha') }
+    let(:commit_double) { double('commit', sha: 'commit_sha') }
+
+    before do
+      allow(octokit_client).to receive(:ref).and_return(ref_double)
+      allow(octokit_client).to receive(:create_blob).and_return('blob_sha')
+      allow(octokit_client).to receive(:create_tree).and_return(tree_double)
+      allow(octokit_client).to receive(:create_commit).and_return(commit_double)
+      allow(octokit_client).to receive(:update_ref)
+    end
+
+    let(:files) { [{ path: 'README.md', old_path: 'README.md', content: '# Hello', is_delete: false }] }
+
+    it 'creates a blob, tree, commit and updates ref' do
+      github.commit_push('myrepo', files, '2024/01/01 00:00:00')
+      expect(octokit_client).to have_received(:create_blob)
+      expect(octokit_client).to have_received(:create_tree)
+      expect(octokit_client).to have_received(:create_commit)
+      expect(octokit_client).to have_received(:update_ref)
+    end
+
+    context 'when deleting a file' do
+      let(:files) { [{ path: 'old.md', old_path: 'old.md', content: '', is_delete: true }] }
+
+      it 'does not create a blob for the deleted file' do
+        github.commit_push('myrepo', files, '2024/01/01 00:00:00')
+        expect(octokit_client).not_to have_received(:create_blob)
+      end
+    end
+
+    context 'when renaming a file' do
+      let(:files) { [{ path: 'new.md', old_path: 'old.md', content: '# Renamed', is_delete: false }] }
+
+      it 'creates a blob for the new file and marks the old path for deletion' do
+        github.commit_push('myrepo', files, '2024/01/01 00:00:00')
+        expect(octokit_client).to have_received(:create_blob).once
+        expect(octokit_client).to have_received(:create_tree) do |_repo, blobs, _opts|
+          delete_blob = blobs.find { |b| b[:path] == 'old.md' }
+          expect(delete_blob[:sha]).to be_nil
+        end
+      end
+    end
+
+    context 'when GitHub API raises an error' do
+      before { allow(octokit_client).to receive(:ref).and_raise(Octokit::Error) }
+
+      it 'returns failure' do
+        result = github.commit_push('myrepo', files, '2024/01/01 00:00:00')
+        expect(result[:success]).to be false
+      end
+    end
+  end
+end

--- a/back/spec/spec_helper.rb
+++ b/back/spec/spec_helper.rb
@@ -1,0 +1,11 @@
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+end

--- a/back/spec/support/devise_token_auth_helpers.rb
+++ b/back/spec/support/devise_token_auth_helpers.rb
@@ -1,0 +1,5 @@
+module DeviseTokenAuthHelpers
+  def auth_headers(user)
+    user.create_new_auth_token
+  end
+end


### PR DESCRIPTION
## Summary

- RSpec, FactoryBot, shoulda-matchers, WebMockのテスト環境をセットアップ
- モデルスペック (User, Record)、リクエストスペック (Users, Records)、サービススペック (Github) を追加
- DeviseTokenAuthヘルパーでリクエストスペックの認証を簡潔化

## Commits

1. `feat: RSpecテスト環境のセットアップ` — Gemfile依存追加、.rspec、rails_helper、spec_helper、DB・テスト環境設定
2. `test: FactoryBotファクトリ追加 (User, Record)`
3. `test: DeviseTokenAuthヘルパー追加`
4. `test: モデルスペック追加 (User, Record)`
5. `test: リクエストスペック追加 (Users, Records)`
6. `test: Githubサービススペック追加`

## Test plan

- [ ] `bundle install` が通ること
- [ ] `bundle exec rspec` で全テストがパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)