### PR TITLE
chore: TypeScript 6.0.3にバージョンアップ

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -43,7 +43,7 @@
     "jsdom": "^24.0.0",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5",
+    "typescript": "^6.0.3",
     "vitest": "^1.6.0",
     "webpack": "^5.91.0"
   }

--- a/front/src/types/css.d.ts
+++ b/front/src/types/css.d.ts
@@ -1,0 +1,1 @@
+declare module "*.css" {}

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -5913,10 +5913,10 @@ typed-array-length@^1.0.6:
     is-typed-array "^1.1.13"
     possible-typed-array-names "^1.0.0"
 
-typescript@^5:
-  version "5.4.5"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz"
-  integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
+typescript@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
+  integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
 
 ufo@^1.6.3:
   version "1.6.3"


### PR DESCRIPTION
closes #23

## Summary
- `typescript` を `^5` → `^6.0.3` に更新
- TypeScript 6.0 の破壊的変更（CSSサイドエフェクトインポートへの型宣言必須化）に対応するため `front/src/types/css.d.ts` を追加

## Test plan
- [ ] `yarn build` でビルドエラーなし（ローカル確認済み）
- [ ] CI (Vitest) の通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)