### PR TITLE
feat: axios を fetch API に置き換え

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -18,7 +18,6 @@
     "@radix-ui/react-menubar": "^1.0.4",
     "@radix-ui/react-select": "^2.0.0",
     "@vercel/analytics": "^1.2.2",
-    "axios": "^1.6.8",
     "clsx": "^2.1.1",
     "next": "15.5.15",
     "react": "^18",

--- a/front/src/__tests__/api/auth.test.ts
+++ b/front/src/__tests__/api/auth.test.ts
@@ -1,59 +1,43 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import axios from 'axios'
+import { authFetch } from '@/api/auth'
 
-vi.mock('axios', async () => {
-  const actual = await vi.importActual<typeof import('axios')>('axios')
-  return {
-    default: {
-      ...actual.default,
-      create: vi.fn(() => ({
-        get: vi.fn(),
-        delete: vi.fn(),
-        interceptors: {
-          request: { use: vi.fn() },
-          response: { use: vi.fn() },
-        },
-      })),
-    },
-  }
-})
-
-describe('authClientインターセプター', () => {
+describe('authFetch', () => {
   beforeEach(() => {
     localStorage.clear()
+    vi.restoreAllMocks()
   })
 
-  it('localStorageの値をリクエストヘッダーに付加する', () => {
+  it('localStorageの値をリクエストヘッダーに付加する', async () => {
     localStorage.setItem('access-token', 'test-token')
     localStorage.setItem('client', 'test-client')
     localStorage.setItem('uid', 'test-uid')
     localStorage.setItem('expiry', '9999999999')
 
-    // interceptor が localStorage の値をヘッダーに付加することを確認
-    const config = { headers: {} as Record<string, string | null> }
-    const applyInterceptor = (cfg: typeof config) => {
-      cfg.headers['access-token'] = localStorage.getItem('access-token')
-      cfg.headers['client'] = localStorage.getItem('client')
-      cfg.headers['uid'] = localStorage.getItem('uid')
-      cfg.headers['expiry'] = localStorage.getItem('expiry')
-      return cfg
-    }
+    const mockFetch = vi.fn().mockResolvedValue({
+      status: 200,
+      json: () => Promise.resolve({ success: true }),
+    })
+    vi.stubGlobal('fetch', mockFetch)
 
-    const result = applyInterceptor(config)
-    expect(result.headers['access-token']).toBe('test-token')
-    expect(result.headers['client']).toBe('test-client')
-    expect(result.headers['uid']).toBe('test-uid')
-    expect(result.headers['expiry']).toBe('9999999999')
+    await authFetch('/me')
+
+    const [, options] = mockFetch.mock.calls[0] as [string, RequestInit & { headers: Record<string, string> }]
+    expect(options.headers['access-token']).toBe('test-token')
+    expect(options.headers['client']).toBe('test-client')
+    expect(options.headers['uid']).toBe('test-uid')
+    expect(options.headers['expiry']).toBe('9999999999')
   })
 
-  it('localStorageが空の場合ヘッダーにnullを返す', () => {
-    const config = { headers: {} as Record<string, string | null> }
-    const applyInterceptor = (cfg: typeof config) => {
-      cfg.headers['access-token'] = localStorage.getItem('access-token')
-      return cfg
-    }
+  it('localStorageが空の場合ヘッダーにaccess-tokenが含まれない', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      status: 200,
+      json: () => Promise.resolve({}),
+    })
+    vi.stubGlobal('fetch', mockFetch)
 
-    const result = applyInterceptor(config)
-    expect(result.headers['access-token']).toBeNull()
+    await authFetch('/me')
+
+    const [, options] = mockFetch.mock.calls[0] as [string, RequestInit & { headers: Record<string, string> }]
+    expect(options.headers['access-token']).toBeUndefined()
   })
 })

--- a/front/src/api/auth.ts
+++ b/front/src/api/auth.ts
@@ -4,6 +4,15 @@ const BASE_API_URL = process.env.NEXT_PUBLIC_API_URL;
 const API_VERSION = process.env.NEXT_PUBLIC_API_VERSION;
 const API_URL = `${BASE_API_URL}/api/${API_VERSION}`;
 
+interface FetchOptions extends Omit<RequestInit, "headers"> {
+  headers?: Record<string, string>;
+}
+
+interface AuthResponse {
+  success: boolean;
+  user: { id: number; name: string };
+}
+
 function getAuthHeaders(): Record<string, string> {
   if (typeof window === "undefined") return {};
   const headers: Record<string, string> = {};
@@ -18,31 +27,31 @@ function getAuthHeaders(): Record<string, string> {
   return headers;
 }
 
-export async function authFetch(
+export async function authFetch<T>(
   path: string,
-  options: RequestInit = {}
-): Promise<{ status: number; data: unknown }> {
+  options: FetchOptions = {}
+): Promise<{ status: number; data: T }> {
   const res = await fetch(`${API_URL}${path}`, {
     ...options,
     headers: {
       "Content-Type": "application/json",
       ...getAuthHeaders(),
-      ...(options.headers as Record<string, string>),
+      ...options.headers,
     },
   });
   const data = await res.json().catch(() => null);
   return { status: res.status, data };
 }
 
-async function baseFetch(
+async function baseFetch<T>(
   path: string,
-  options: RequestInit = {}
-): Promise<{ status: number; data: unknown }> {
+  options: FetchOptions = {}
+): Promise<{ status: number; data: T }> {
   const res = await fetch(`${BASE_API_URL}${path}`, {
     ...options,
     headers: {
       "Content-Type": "application/json",
-      ...(options.headers as Record<string, string>),
+      ...options.headers,
     },
   });
   const data = await res.json().catch(() => null);
@@ -57,17 +66,16 @@ export const useAuth = () => {
   }
 
   async function autoLogin(): Promise<boolean> {
-    const res = await authFetch("/me");
+    const res = await authFetch<AuthResponse>("/me");
     if (res.status !== 200) {
       clearStorage();
       return false;
     }
-    const data = res.data as { success: boolean; user: { id: number; name: string } };
-    if (!data.success) {
+    if (!res.data.success) {
       clearStorage();
       return false;
     }
-    setUser({ id: data.user.id, name: data.user.name });
+    setUser({ id: res.data.user.id, name: res.data.user.name });
     return true;
   }
 
@@ -85,22 +93,21 @@ export const useAuth = () => {
     if (uid && client && token && expiry) {
       setStorage({ accessToken: token, client, uid, expiry });
     }
-    const res = await authFetch("/me");
+    const res = await authFetch<AuthResponse>("/me");
     if (res.status !== 200) {
       clearStorage();
       return false;
     }
-    const data = res.data as { success: boolean; user: { id: number; name: string } };
-    if (!data.success) {
+    if (!res.data.success) {
       clearStorage();
       return false;
     }
-    setUser({ id: data.user.id, name: data.user.name });
+    setUser({ id: res.data.user.id, name: res.data.user.name });
     return true;
   }
 
   async function logout(): Promise<boolean> {
-    const res = await baseFetch("/auth/sign_out", {
+    const res = await baseFetch<null>("/auth/sign_out", {
       method: "DELETE",
       headers: {
         "access-token": localStorage.getItem("access-token") ?? "",

--- a/front/src/api/auth.ts
+++ b/front/src/api/auth.ts
@@ -1,61 +1,76 @@
 import { useSetUserState } from "@/store";
-import axios from "axios";
 
 const BASE_API_URL = process.env.NEXT_PUBLIC_API_URL;
 const API_VERSION = process.env.NEXT_PUBLIC_API_VERSION;
-const API_URL = `${BASE_API_URL}/api/${API_VERSION}/`;
+const API_URL = `${BASE_API_URL}/api/${API_VERSION}`;
 
-const baseClient = axios.create({
-  baseURL: BASE_API_URL,
-  headers: {
-    "Content-Type": "application/json",
-  },
-});
+function getAuthHeaders(): Record<string, string> {
+  if (typeof window === "undefined") return {};
+  const headers: Record<string, string> = {};
+  const accessToken = localStorage.getItem("access-token");
+  const client = localStorage.getItem("client");
+  const uid = localStorage.getItem("uid");
+  const expiry = localStorage.getItem("expiry");
+  if (accessToken) headers["access-token"] = accessToken;
+  if (client) headers["client"] = client;
+  if (uid) headers["uid"] = uid;
+  if (expiry) headers["expiry"] = expiry;
+  return headers;
+}
 
-export const authClient = axios.create({
-  baseURL: API_URL,
-  headers: {
-    "Content-Type": "application/json",
-  },
-});
+export async function authFetch(
+  path: string,
+  options: RequestInit = {}
+): Promise<{ status: number; data: unknown }> {
+  const res = await fetch(`${API_URL}${path}`, {
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...getAuthHeaders(),
+      ...(options.headers as Record<string, string>),
+    },
+  });
+  const data = await res.json().catch(() => null);
+  return { status: res.status, data };
+}
 
-authClient.interceptors.request.use((config) => {
-  if (typeof window !== "undefined") {
-    config.headers["access-token"] = localStorage.getItem("access-token");
-    config.headers.client = localStorage.getItem("client");
-    config.headers.uid = localStorage.getItem("uid");
-    config.headers.expiry = localStorage.getItem("expiry");
-  }
-  return config;
-});
+async function baseFetch(
+  path: string,
+  options: RequestInit = {}
+): Promise<{ status: number; data: unknown }> {
+  const res = await fetch(`${BASE_API_URL}${path}`, {
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...(options.headers as Record<string, string>),
+    },
+  });
+  const data = await res.json().catch(() => null);
+  return { status: res.status, data };
+}
 
 export const useAuth = () => {
   const setUser = useSetUserState();
 
-  // GitHubでログイン
   async function login(): Promise<void> {
     window.location.href = `${BASE_API_URL}/auth/github`;
   }
 
-  // 自動ログイン
   async function autoLogin(): Promise<boolean> {
-    const res = await authClient.get("/me");
+    const res = await authFetch("/me");
     if (res.status !== 200) {
       clearStorage();
       return false;
     }
-
-    const data = res.data;
+    const data = res.data as { success: boolean; user: { id: number; name: string } };
     if (!data.success) {
       clearStorage();
       return false;
     }
-
     setUser({ id: data.user.id, name: data.user.name });
     return true;
   }
 
-  // 現在ユーザーの取得
   async function currentUser({
     uid = "",
     client = "",
@@ -70,38 +85,34 @@ export const useAuth = () => {
     if (uid && client && token && expiry) {
       setStorage({ accessToken: token, client, uid, expiry });
     }
-    const res = await authClient.get("/me");
+    const res = await authFetch("/me");
     if (res.status !== 200) {
       clearStorage();
       return false;
     }
-
-    const data = res.data;
+    const data = res.data as { success: boolean; user: { id: number; name: string } };
     if (!data.success) {
       clearStorage();
       return false;
     }
-
     setUser({ id: data.user.id, name: data.user.name });
     return true;
   }
 
-  // ログアウト
   async function logout(): Promise<boolean> {
-    const res = await baseClient.delete("/auth/sign_out", {
+    const res = await baseFetch("/auth/sign_out", {
+      method: "DELETE",
       headers: {
-        "access-token": localStorage.getItem("access-token"),
-        client: localStorage.getItem("client"),
-        uid: localStorage.getItem("uid"),
-        expiry: localStorage.getItem("expiry"),
+        "access-token": localStorage.getItem("access-token") ?? "",
+        client: localStorage.getItem("client") ?? "",
+        uid: localStorage.getItem("uid") ?? "",
+        expiry: localStorage.getItem("expiry") ?? "",
       },
     });
     if (res.status !== 200) {
       return false;
     }
-
     clearStorage();
-
     setUser({ id: null, name: "" });
     return true;
   }
@@ -125,10 +136,5 @@ export const useAuth = () => {
     localStorage.removeItem("expiry");
   };
 
-  return {
-    login,
-    currentUser,
-    logout,
-    autoLogin,
-  };
+  return { login, currentUser, logout, autoLogin };
 };

--- a/front/src/api/index.ts
+++ b/front/src/api/index.ts
@@ -1,3 +1,3 @@
-import { useAuth, authClient } from "./auth";
+import { useAuth, authFetch } from "./auth";
 
-export { useAuth, authClient };
+export { useAuth, authFetch };

--- a/front/src/app/record/[name]/page.tsx
+++ b/front/src/app/record/[name]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { authClient } from "@/api";
+import { authFetch } from "@/api";
 import { Editor, FixedButtonPC, FixedButtonSP } from "@/components/records";
 import { useRouter } from "next/navigation";
 import { use, useCallback, useEffect, useState } from "react";
@@ -33,7 +33,7 @@ export default function RecordPage({
   const fetchData = useCallback(async () => {
     try {
       setIsLoading(true);
-      const res = await authClient.get(`/records/${name}`);
+      const res = await authFetch(`/records/${name}`);
       if (res.status === 500) {
         alert("エラーが発生しました");
         return;
@@ -43,25 +43,26 @@ export default function RecordPage({
         return;
       }
 
-      if (res.data.success === false) {
-        alert(res.data.message);
+      const fetchData = res.data as { success: boolean; message: string; files: IFile[] };
+      if (fetchData.success === false) {
+        alert(fetchData.message);
         const currentRecord = records.filter((record) => record.name !== name);
         setRecords(currentRecord);
         router.push("/record");
         return;
       }
 
-      let files = res.data.files || [];
+      let files = fetchData.files || [];
       if (files.length === 0) {
         return;
       }
 
-      files = files.map((file: IFile, index: number) => {
+      files = files.map((file, index) => {
         return {
           ...file,
           id: index,
           is_delete: false,
-          old_path: file.path,
+          old_path: file.path ?? "",
         };
       });
 
@@ -275,8 +276,9 @@ export default function RecordPage({
         };
       });
 
-      const res = await authClient.patch(`/records/${name}`, {
-        files: updateAllFile,
+      const res = await authFetch(`/records/${name}`, {
+        method: "PATCH",
+        body: JSON.stringify({ files: updateAllFile }),
       });
       if (res.status === 500) {
         alert("エラーが発生しました");
@@ -287,10 +289,11 @@ export default function RecordPage({
         return;
       }
 
-      if (res.data.success === false) {
-        const message = Array.isArray(res.data.message)
-          ? res.data.message.join("\n")
-          : res.data.message;
+      const saveData = res.data as { success: boolean; message: string | string[] };
+      if (saveData.success === false) {
+        const message = Array.isArray(saveData.message)
+          ? saveData.message.join("\n")
+          : saveData.message;
         alert(message);
         return;
       }

--- a/front/src/app/record/[name]/page.tsx
+++ b/front/src/app/record/[name]/page.tsx
@@ -5,7 +5,7 @@ import { Editor, FixedButtonPC, FixedButtonSP } from "@/components/records";
 import { useRouter } from "next/navigation";
 import { use, useCallback, useEffect, useState } from "react";
 import { FaFile } from "react-icons/fa";
-import { IFile } from "@/types";
+import { IFile, RecordFilesResponse, RecordMutationResponse } from "@/types";
 import { useRecordsState } from "@/store";
 
 export default function RecordPage({
@@ -33,7 +33,7 @@ export default function RecordPage({
   const fetchData = useCallback(async () => {
     try {
       setIsLoading(true);
-      const res = await authFetch(`/records/${name}`);
+      const res = await authFetch<RecordFilesResponse>(`/records/${name}`);
       if (res.status === 500) {
         alert("エラーが発生しました");
         return;
@@ -43,16 +43,15 @@ export default function RecordPage({
         return;
       }
 
-      const fetchData = res.data as { success: boolean; message: string; files: IFile[] };
-      if (fetchData.success === false) {
-        alert(fetchData.message);
+      if (res.data.success === false) {
+        alert(res.data.message);
         const currentRecord = records.filter((record) => record.name !== name);
         setRecords(currentRecord);
         router.push("/record");
         return;
       }
 
-      let files = fetchData.files || [];
+      let files = res.data.files || [];
       if (files.length === 0) {
         return;
       }
@@ -276,7 +275,7 @@ export default function RecordPage({
         };
       });
 
-      const res = await authFetch(`/records/${name}`, {
+      const res = await authFetch<RecordMutationResponse>(`/records/${name}`, {
         method: "PATCH",
         body: JSON.stringify({ files: updateAllFile }),
       });
@@ -289,11 +288,10 @@ export default function RecordPage({
         return;
       }
 
-      const saveData = res.data as { success: boolean; message: string | string[] };
-      if (saveData.success === false) {
-        const message = Array.isArray(saveData.message)
-          ? saveData.message.join("\n")
-          : saveData.message;
+      if (res.data.success === false) {
+        const message = Array.isArray(res.data.message)
+          ? res.data.message.join("\n")
+          : res.data.message;
         alert(message);
         return;
       }

--- a/front/src/app/record/page.tsx
+++ b/front/src/app/record/page.tsx
@@ -1,7 +1,8 @@
 "use client";
-import { authClient, useAuth } from "@/api";
+import { authFetch, useAuth } from "@/api";
 import { CreateRecord, RecordList } from "@/components/records";
 import { useUserState, useRecordsState } from "@/store";
+import type { IRecord } from "@/types";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import * as Shadcn from "@/components/shadcn";
@@ -49,17 +50,18 @@ export default function UserPage() {
     }
     try {
       setIsLoading(true);
-      const res = await authClient.get("/records");
+      const res = await authFetch("/records");
       if (res.status !== 200) {
         alert("エラーが発生しました");
         return;
       }
 
-      if (res.data.length === 0) {
+      const data = res.data as IRecord[];
+      if (data.length === 0) {
         setRecords([]);
         return;
       }
-      setRecords(res.data);
+      setRecords(data);
     } catch (e) {
       alert("エラーが発生しました");
     } finally {

--- a/front/src/app/record/page.tsx
+++ b/front/src/app/record/page.tsx
@@ -50,18 +50,17 @@ export default function UserPage() {
     }
     try {
       setIsLoading(true);
-      const res = await authFetch("/records");
+      const res = await authFetch<IRecord[]>("/records");
       if (res.status !== 200) {
         alert("エラーが発生しました");
         return;
       }
 
-      const data = res.data as IRecord[];
-      if (data.length === 0) {
+      if (res.data.length === 0) {
         setRecords([]);
         return;
       }
-      setRecords(data);
+      setRecords(res.data);
     } catch (e) {
       alert("エラーが発生しました");
     } finally {

--- a/front/src/components/records/createRecord.tsx
+++ b/front/src/components/records/createRecord.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { authClient } from "@/api";
+import { authFetch } from "@/api";
 import { useRecordsState } from "@/store";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -24,8 +24,9 @@ export default function CreateRecord({
     }
     try {
       setIsLoading(true);
-      const res = await authClient.post("/records", {
-        repository_name: recordName,
+      const res = await authFetch("/records", {
+        method: "POST",
+        body: JSON.stringify({ repository_name: recordName }),
       });
       await new Promise((resolve) => setTimeout(resolve, 2000));
       if (res.status === 500) {
@@ -37,8 +38,9 @@ export default function CreateRecord({
         return;
       }
 
-      alert(res.data.message);
-      if (!res.data.success) return;
+      const data = res.data as { success: boolean; message: string };
+      alert(data.message);
+      if (!data.success) return;
 
       setRecordName("");
 

--- a/front/src/components/records/createRecord.tsx
+++ b/front/src/components/records/createRecord.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { authFetch } from "@/api";
 import { useRecordsState } from "@/store";
+import type { CreateRecordResponse } from "@/types";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
@@ -24,7 +25,7 @@ export default function CreateRecord({
     }
     try {
       setIsLoading(true);
-      const res = await authFetch("/records", {
+      const res = await authFetch<CreateRecordResponse>("/records", {
         method: "POST",
         body: JSON.stringify({ repository_name: recordName }),
       });
@@ -38,9 +39,8 @@ export default function CreateRecord({
         return;
       }
 
-      const data = res.data as { success: boolean; message: string };
-      alert(data.message);
-      if (!data.success) return;
+      alert(res.data.message);
+      if (!res.data.success) return;
 
       setRecordName("");
 

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -18,3 +18,19 @@ export interface IRecord {
   private: boolean;
   created_at: string;
 }
+
+export interface RecordFilesResponse {
+  success: boolean;
+  message: string;
+  files: IFile[];
+}
+
+export interface RecordMutationResponse {
+  success: boolean;
+  message: string | string[];
+}
+
+export interface CreateRecordResponse {
+  success: boolean;
+  message: string;
+}

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -2727,11 +2727,6 @@ async@^3.2.3:
   resolved "https://registry.npmjs.org/async/-/async-3.2.5.tgz"
   integrity sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==
 
-asynckit@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
-  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
-
 at-least-node@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz"
@@ -2748,15 +2743,6 @@ axe-core@^4.10.0:
   version "4.11.3"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.11.3.tgz#d23cf404edaa5f97bdfd9afed6eea8405e5326e7"
   integrity sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==
-
-axios@^1.6.8:
-  version "1.6.8"
-  resolved "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz"
-  integrity sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==
-  dependencies:
-    follow-redirects "^1.15.6"
-    form-data "^4.0.0"
-    proxy-from-env "^1.1.0"
 
 axobject-query@^4.1.0:
   version "4.1.0"
@@ -2953,13 +2939,6 @@ color-name@~1.1.4:
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-combined-stream@^1.0.8:
-  version "1.0.8"
-  resolved "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz"
-  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
-  dependencies:
-    delayed-stream "~1.0.0"
-
 commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz"
@@ -3152,11 +3131,6 @@ del@^4.1.1:
     p-map "^2.0.0"
     pify "^4.0.1"
     rimraf "^2.6.3"
-
-delayed-stream@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 dequal@^2.0.3:
   version "2.0.3"
@@ -3824,11 +3798,6 @@ flatted@^3.2.9:
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz"
   integrity sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==
 
-follow-redirects@^1.15.6:
-  version "1.15.6"
-  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz"
-  integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
-
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz"
@@ -3842,15 +3811,6 @@ for-each@^0.3.5:
   integrity sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==
   dependencies:
     is-callable "^1.2.7"
-
-form-data@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz"
-  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    mime-types "^2.1.12"
 
 fs-extra@^9.0.1:
   version "9.1.0"
@@ -4905,7 +4865,7 @@ mime-db@1.52.0:
   resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.12, mime-types@^2.1.27:
+mime-types@^2.1.27:
   version "2.1.35"
   resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -5272,11 +5232,6 @@ prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
-
-proxy-from-env@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 punycode@^2.1.0, punycode@^2.3.1:
   version "2.3.1"


### PR DESCRIPTION
## Summary

- `axios` を削除し、ネイティブの fetch API に置き換え
- `authClient`（axios インスタンス）→ `authFetch` 関数として再実装
  - リクエストインターセプターの代わりに `getAuthHeaders()` で localStorage から認証ヘッダーを付加
  - `baseFetch` でログアウト用のベース URL リクエストを処理
- 各ページ・コンポーネントの呼び出し箇所を更新
  - `authClient.get(path)` → `authFetch(path)`
  - `authClient.post(path, body)` → `authFetch(path, { method: "POST", body: JSON.stringify(body) })`
  - `authClient.patch(path, body)` → `authFetch(path, { method: "PATCH", body: JSON.stringify(body) })`
- テストを axios モックから `vi.stubGlobal('fetch', ...)` に書き直し

## Test plan

- [x] `yarn test` で全テスト（2件）がパスすることを確認
- [x] `yarn build` が成功することを確認

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)