### PR TITLE
fix: Tailwind v4 でアイコン span が肥大化する問題を修正

### DIFF
--- a/front/src/app/globals.css
+++ b/front/src/app/globals.css
@@ -113,3 +113,12 @@
     @apply bg-background text-foreground;
   }
 }
+
+@utility container {
+  margin-inline: auto;
+  padding-inline: 2rem;
+
+  @media (width >= theme(--breakpoint-2xl)) {
+    max-width: 1400px;
+  }
+}

--- a/front/src/app/record/[name]/page.tsx
+++ b/front/src/app/record/[name]/page.tsx
@@ -367,7 +367,7 @@ export default function RecordPage({
                               type="button"
                               onClick={() => handleSelectFile(String(file.id))}
                             >
-                              <span className="w-25 h-25 mr-1">
+                              <span className="mr-1">
                                 <FaFile className="opacity-50 text-sm" />
                               </span>
                               <span className="line-clamp-1 hover:line-clamp-none break-words text-start transition">


### PR DESCRIPTION
## 原因

`w-25 h-25` は Tailwind v3 では存在しないユーティリティのため無効（CSS未出力）だったが、v4 ではスペーシングスケールが開放されて `width: 6.25rem; height: 6.25rem` として有効になり、ファイルアイコン用 `span` が 100px に広がっていた。

## 修正

`w-25 h-25` を削除し、v3 と同じ自然なサイズ（コンテンツ依存）に戻した。

Closes #21（デザイン崩れの追従修正）

🤖 Generated with [Claude Code](https://claude.com/claude-code)