### PR TITLE
fix: Tailwind v4 移行後のデザイン修正（container 設定・opacity）

### DIFF
--- a/front/src/app/record/[name]/page.tsx
+++ b/front/src/app/record/[name]/page.tsx
@@ -323,13 +323,13 @@ export default function RecordPage({
         </div>
         <div className="w-full flex gap-2">
           {isLoading ? (
-            <section className="hidden md:block w-1/5 border-2 border-blue-300 border-opacity-40 rounded my-8 top-5 h-[140px] animate-pulse">
+            <section className="hidden md:block w-1/5 border-2 border-blue-300/40 rounded my-8 top-5 h-[140px] animate-pulse">
               <div className="h-full bg-blue-200 opacity-50 flex justify-center items-center">
                 <p className="text-black text-center">読込中</p>
               </div>
             </section>
           ) : (
-            <section className="hidden md:block w-1/5 bg-blue-200 bg-opacity-20 border-2 border-blue-300 border-opacity-40 rounded p-4 my-8 sticky top-5 h-full">
+            <section className="hidden md:block w-1/5 bg-blue-200/20 border-2 border-blue-300/40 rounded p-4 my-8 sticky top-5 h-full">
               <h3 className="text-start mb-2">記録</h3>
               <div className="ml-3 overflow-hidden">
                 <form className="w-full mb-4" onSubmit={handleCreateFile}>


### PR DESCRIPTION
## Summary

- `@utility container` を追加し、v3 の container 設定を v4 で復元
  - `margin-inline: auto`（`center: true` の代替）
  - `padding-inline: 2rem`（`padding: "2rem"` の代替）
  - 2xl の `max-width: 1400px`（カスタム screens の代替）
- `bg-opacity-20` / `border-opacity-40` を v4 のスラッシュ構文（`bg-blue-200/20` / `border-blue-300/40`）に変更

## Test plan

- [x] `yarn build` が成功することを確認
- [x] 本番環境で左カラムのサイズが正常であることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)