### PR TITLE
fix: Tailwind v4 preflight で input 背景が透過される問題を修正

### DIFF
--- a/front/src/app/record/[name]/page.tsx
+++ b/front/src/app/record/[name]/page.tsx
@@ -335,7 +335,7 @@ export default function RecordPage({
                 <form className="w-full mb-4" onSubmit={handleCreateFile}>
                   <input
                     type="text"
-                    className="rounded w-full text-black p-1 px-2 focus:outline-none"
+                    className="rounded w-full bg-white text-black p-1 px-2 focus:outline-none"
                     onChange={(e) => setFileName(e.target.value)}
                     value={fileName}
                     placeholder="README"

--- a/front/src/components/records/createRecord.tsx
+++ b/front/src/components/records/createRecord.tsx
@@ -86,7 +86,7 @@ export default function CreateRecord({
       <div className="relative flex flex-col gap-2">
         <input
           type="text"
-          className="text-black p-2 rounded"
+          className="bg-white text-black p-2 rounded"
           onChange={handleSetName}
           value={recordName}
         />


### PR DESCRIPTION
## Summary

- v4 の preflight が input 要素の背景色を `transparent` にリセットするようになったため、白背景だった入力欄が透過して見える問題を修正
- ファイル名入力欄（`record/[name]/page.tsx`）と リポジトリ名入力欄（`createRecord.tsx`）に `bg-white` を追加
- `editor.tsx` の textarea は意図的に `bg-transparent` なので変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)