### PR TITLE
chore(front): add tsgo typecheck and TypeScript 6 resolutions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,11 +38,17 @@ docker compose exec back bundle exec rails db:schema:load           # テストD
 ```bash
 docker compose exec front yarn dev        # 開発サーバー（ポート8000）
 docker compose exec front yarn build
+docker compose exec front yarn typecheck  # 型チェック（TypeScript 7 系 tsgo）
+docker compose exec front yarn typecheck:tsc  # 型チェック（従来の tsc。比較用）
 docker compose exec front yarn test       # Vitest（単体テスト）
 docker compose exec front yarn test:watch
 docker compose exec front yarn test:e2e  # Playwright（E2E）
 docker compose exec front yarn lint
 ```
+
+`front` は `./front:/app` でマウントするため、**初回・依存更新後**はホストかコンテナのどちらかで `yarn install` 済みであること（`node_modules` 必須）。初回だけ例: `docker compose run --rm --no-deps front yarn install`。
+
+`typescript` は **6 系**（`tsc`・エディタ・Next/ESLint の前提）。高速型チェックの **tsgo** は `devDependencies` の `@typescript/native-preview` が供し、`yarn typecheck` で使う。`resolutions` で入れ子依存も TypeScript 6 に揃えている。
 
 ## Git ワークフロー
 

--- a/front/package.json
+++ b/front/package.json
@@ -7,6 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "typecheck": "tsgo -p . --noEmit",
+    "typecheck:tsc": "tsc -p . --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test"
@@ -27,23 +29,27 @@
     "vaul": "^0.9.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.44.0",
+    "@tailwindcss/postcss": "^4.2.4",
+    "@testing-library/jest-dom": "^6.4.0",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.5.0",
     "@types/node": "^24.12.2",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@typescript/native-preview": "^7.0.0-dev.20260421.2",
     "@vitejs/plugin-react": "^6.0.1",
-    "@testing-library/react": "^16.0.0",
-    "@testing-library/jest-dom": "^6.4.0",
-    "@testing-library/user-event": "^14.5.0",
-    "@playwright/test": "^1.44.0",
     "eslint": "^8",
     "eslint-config-next": "15.5.15",
     "jsdom": "^29.0.2",
-    "@tailwindcss/postcss": "^4.2.4",
     "postcss": "^8",
     "tailwindcss": "^4.2.4",
     "tw-animate-css": "^1.4.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.5",
     "webpack": "^5.91.0"
+  },
+  "resolutions": {
+    "typescript": "^6.0.3"
   }
 }

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -2269,6 +2269,54 @@
     "@typescript-eslint/types" "8.58.2"
     eslint-visitor-keys "^5.0.0"
 
+"@typescript/native-preview-darwin-arm64@7.0.0-dev.20260421.2":
+  version "7.0.0-dev.20260421.2"
+  resolved "https://registry.yarnpkg.com/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260421.2.tgz#8d2a1a9febf3759dcaddc6d5731874f4df01f003"
+  integrity sha512-fHv1r3ZmVo6zxuAIFmuX3w9QxbcauoG0SsWhmDwm6VmRubLlOJIcmTtlmV3JAb9oOnq8LuzZljzT7Q39fSMQDw==
+
+"@typescript/native-preview-darwin-x64@7.0.0-dev.20260421.2":
+  version "7.0.0-dev.20260421.2"
+  resolved "https://registry.yarnpkg.com/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260421.2.tgz#1f878dedaf60505d7b67505dbe47b44503593e09"
+  integrity sha512-KWTR6xbW9t+JS7D5DQIzo75pqVXVWUxF9PMv/+S6xsnOjCVd6g0ixHcFpFMJMKSUQpGPr8Z5f7b8ks6LHW01jg==
+
+"@typescript/native-preview-linux-arm64@7.0.0-dev.20260421.2":
+  version "7.0.0-dev.20260421.2"
+  resolved "https://registry.yarnpkg.com/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260421.2.tgz#529465d6436de4ee0ed922d7de2e91fb605d7622"
+  integrity sha512-VLMEuml3BhUb+jaL0TXQ4xvVODxJF+RhkI+tBWvlynsJI4khTXEiwWh+wPOJrsfBRYFRMXEu28Odl/HXkYze8w==
+
+"@typescript/native-preview-linux-arm@7.0.0-dev.20260421.2":
+  version "7.0.0-dev.20260421.2"
+  resolved "https://registry.yarnpkg.com/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260421.2.tgz#cb5abde3e2fed1ed1c1aff1f22338a4f4c1d4a7b"
+  integrity sha512-BWLQO3nemLDSV5PoE5GPHe1dU9Dth77Kv8/cle9Ujcp4LhPo0KincdPqFH/qKeU/xvW25mgFueflZ1nc4rKuww==
+
+"@typescript/native-preview-linux-x64@7.0.0-dev.20260421.2":
+  version "7.0.0-dev.20260421.2"
+  resolved "https://registry.yarnpkg.com/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260421.2.tgz#a8ca0d1ceb4659027878b915276ebcfa0ab93130"
+  integrity sha512-qUrJWTB5/wv4wnRG0TRXElAxc2kykNiRNyEIEqBbLmzDlrcvAW7RRy8MXoY1ZyTiKGMu14itZ3x9oW6+blFpRw==
+
+"@typescript/native-preview-win32-arm64@7.0.0-dev.20260421.2":
+  version "7.0.0-dev.20260421.2"
+  resolved "https://registry.yarnpkg.com/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260421.2.tgz#f1165ba01b22697729c16edd6ae4d1629318a7f4"
+  integrity sha512-Rc6NsWlZmCs5YUKVzKgwoBOoRUGsPzct4BDMRX0csD1devLBBc4AbUXWKsJRbpwIAnqMO1ld4sNHEb+wXgfNHQ==
+
+"@typescript/native-preview-win32-x64@7.0.0-dev.20260421.2":
+  version "7.0.0-dev.20260421.2"
+  resolved "https://registry.yarnpkg.com/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260421.2.tgz#01724cea15792e06e9543f1d698141b61fc229fc"
+  integrity sha512-GQv1+dya1t6EqF2Cpsb+xoozovdX10JUSf6Kl/8xNkTapzmlHd+uMr+8ku3jIASTxoRGn0Mklgjj3MDKrOTuLg==
+
+"@typescript/native-preview@^7.0.0-dev.20260421.2":
+  version "7.0.0-dev.20260421.2"
+  resolved "https://registry.yarnpkg.com/@typescript/native-preview/-/native-preview-7.0.0-dev.20260421.2.tgz#5c22e3118533f394dc2cade1e290680f978ba7b7"
+  integrity sha512-CmajHI25HpVWE9R1XFoxr+cphJPxoYD3eFioQtAvXYkMFKnLdICMS9pXre9Pybizb75ejRxjKD5/CVG055rEIg==
+  optionalDependencies:
+    "@typescript/native-preview-darwin-arm64" "7.0.0-dev.20260421.2"
+    "@typescript/native-preview-darwin-x64" "7.0.0-dev.20260421.2"
+    "@typescript/native-preview-linux-arm" "7.0.0-dev.20260421.2"
+    "@typescript/native-preview-linux-arm64" "7.0.0-dev.20260421.2"
+    "@typescript/native-preview-linux-x64" "7.0.0-dev.20260421.2"
+    "@typescript/native-preview-win32-arm64" "7.0.0-dev.20260421.2"
+    "@typescript/native-preview-win32-x64" "7.0.0-dev.20260421.2"
+
 "@ungap/structured-clone@^1.2.0":
   version "1.2.0"
   resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz"


### PR DESCRIPTION
- Add @typescript/native-preview, scripts typecheck and typecheck:tsc
- resolutions: force nested deps to TypeScript 6.0.x
- Document Docker usage, mount note, and tsgo vs tsc in CLAUDE.md

Closes #47